### PR TITLE
[Feature] Implements account crud apis

### DIFF
--- a/src/main/java/com/lp/v2/common/response/BaseResponse.java
+++ b/src/main/java/com/lp/v2/common/response/BaseResponse.java
@@ -1,0 +1,35 @@
+package com.lp.v2.common.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.Instant;
+
+@Getter
+@Builder
+@RequiredArgsConstructor
+public class BaseResponse {
+    private final boolean success;
+    private final String message;
+    private final String timestamp;
+    private final int status;
+
+    public static BaseResponse success(ResponseMessage responseMessage) {
+        return BaseResponse.builder()
+                .success(true)
+                .message(responseMessage.getMessage())
+                .timestamp(Instant.now().toString())
+                .status(responseMessage.getStatusCode())
+                .build();
+    }
+
+    public static BaseResponse error(ResponseMessage responseMessage) {
+        return BaseResponse.builder()
+                .success(false)
+                .message(responseMessage.getMessage())
+                .timestamp(Instant.now().toString())
+                .status(responseMessage.getStatusCode())
+                .build();
+    }
+}

--- a/src/main/java/com/lp/v2/common/response/BaseResponse.java
+++ b/src/main/java/com/lp/v2/common/response/BaseResponse.java
@@ -3,6 +3,7 @@ package com.lp.v2.common.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 import java.time.Instant;
 
@@ -30,6 +31,15 @@ public class BaseResponse {
                 .message(responseMessage.getMessage())
                 .timestamp(Instant.now().toString())
                 .status(responseMessage.getStatusCode())
+                .build();
+    }
+
+    public static BaseResponse fail(String message) {
+        return BaseResponse.builder()
+                .success(false)
+                .message(message)
+                .timestamp(Instant.now().toString())
+                .status(HttpStatus.UNAUTHORIZED.value())
                 .build();
     }
 }

--- a/src/main/java/com/lp/v2/common/response/ResponseMessage.java
+++ b/src/main/java/com/lp/v2/common/response/ResponseMessage.java
@@ -1,0 +1,42 @@
+package com.lp.v2.common.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@RequiredArgsConstructor
+public enum ResponseMessage {
+    // 공통 응답
+    SUCCESS("성공", HttpStatus.OK),
+    BAD_REQUEST("잘못된 요청입니다.", HttpStatus.BAD_REQUEST),
+    UNAUTHORIZED("인증이 필요합니다.", HttpStatus.UNAUTHORIZED),
+    FORBIDDEN("접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
+    NOT_FOUND("리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    CONFLICT("충돌이 발생했습니다.", HttpStatus.CONFLICT),
+    INTERNAL_SERVER_ERROR("서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+
+    // 계정 관련 응답
+    ACCOUNT_CREATED_SUCCESS("계정 생성이 완료되었습니다.", HttpStatus.CREATED),
+    ACCOUNT_DUPLICATE_ERROR("이미 존재하는 계정입니다.", HttpStatus.CONFLICT),
+    ACCOUNT_NOT_FOUND("계정을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ACCOUNT_DELETE_SUCCESS("계정 삭제가 완료되었습니다.", HttpStatus.OK),
+    ACCOUNT_UPDATE_SUCCESS("계정 정보가 수정되었습니다.", HttpStatus.OK),
+
+    // 인증 관련 응답
+    LOGIN_SUCCESS("로그인이 완료되었습니다.", HttpStatus.OK),
+    LOGIN_FAILED("로그인에 실패했습니다.", HttpStatus.UNAUTHORIZED),
+    LOGOUT_SUCCESS("로그아웃이 완료되었습니다.", HttpStatus.OK),
+    TOKEN_EXPIRED("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_INVALID("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
+    TOKEN_REFRESH_SUCCESS("토큰 갱신이 완료되었습니다.", HttpStatus.OK),
+    INVALID_CREDENTIALS("잘못된 인증 정보입니다.", HttpStatus.UNAUTHORIZED);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    public int getStatusCode() {
+        return httpStatus.value();
+    }
+}

--- a/src/main/java/com/lp/v2/common/response/ResponseMessage.java
+++ b/src/main/java/com/lp/v2/common/response/ResponseMessage.java
@@ -31,7 +31,8 @@ public enum ResponseMessage {
     TOKEN_EXPIRED("토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     TOKEN_INVALID("유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED),
     TOKEN_REFRESH_SUCCESS("토큰 갱신이 완료되었습니다.", HttpStatus.OK),
-    INVALID_CREDENTIALS("잘못된 인증 정보입니다.", HttpStatus.UNAUTHORIZED);
+    INVALID_CREDENTIALS("잘못된 인증 정보입니다.", HttpStatus.UNAUTHORIZED),
+    PASSWORD_VERIFICATION_SUCCESS("비밀번호 인증이 완료되었습니다.", HttpStatus.OK);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/src/main/java/com/lp/v2/configuration/WebConfig.java
+++ b/src/main/java/com/lp/v2/configuration/WebConfig.java
@@ -1,0 +1,18 @@
+package com.lp.v2.configuration;
+
+import com.lp.v2.security.resolver.CurrentAccountIdArgumentResolver;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        // CurrentAccountIdArgumentResolver 등록
+        resolvers.add(new CurrentAccountIdArgumentResolver());
+    }
+}

--- a/src/main/java/com/lp/v2/domains/account/AccountController.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountController.java
@@ -2,12 +2,10 @@ package com.lp.v2.domains.account;
 
 import com.lp.v2.common.response.BaseResponse;
 import com.lp.v2.common.response.ResponseMessage;
+import com.lp.v2.security.annotation.CurrentAccountId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RestController
@@ -16,11 +14,17 @@ public class AccountController {
 
     private final AccountService accountService;
 
-    @PostMapping
+    @PostMapping("/signup")
     public ResponseEntity<BaseResponse> createAccount(@RequestBody AccountCreateReq req) {
         accountService.create(req);
         return ResponseEntity.ok(
                 BaseResponse.success(ResponseMessage.ACCOUNT_CREATED_SUCCESS)
         );
     }
+
+    @GetMapping("/me")
+    public ResponseEntity<AccountInfoRes> getMyInfo(@CurrentAccountId Long accountId) {
+        return ResponseEntity.ok().body(accountService.getInfo(accountId));
+    }
+
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountController.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountController.java
@@ -38,4 +38,15 @@ public class AccountController {
         );
     }
 
+    @PutMapping("/me")
+    public ResponseEntity<BaseResponse> updateMyInfo(
+            @CurrentAccountId Long accountId,
+            @RequestBody AccountUpdateReq req
+    ) {
+        accountService.update(accountId, req);
+        return ResponseEntity.ok(
+                BaseResponse.success(ResponseMessage.ACCOUNT_UPDATE_SUCCESS)
+        );
+    }
+
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountController.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountController.java
@@ -49,4 +49,12 @@ public class AccountController {
         );
     }
 
+    @DeleteMapping("/me")
+    public ResponseEntity<BaseResponse> deleteMyAccount(@CurrentAccountId Long accountId) {
+        accountService.delete(accountId);
+        return ResponseEntity.ok(
+                BaseResponse.success(ResponseMessage.ACCOUNT_DELETE_SUCCESS)
+        );
+    }
+
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountController.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountController.java
@@ -27,4 +27,15 @@ public class AccountController {
         return ResponseEntity.ok().body(accountService.getInfo(accountId));
     }
 
+    @PostMapping("/verify")
+    public ResponseEntity<BaseResponse> verifyPassword(
+            @CurrentAccountId Long accountId,
+            @RequestBody PasswordVerifyReq req
+    ) {
+        accountService.verifyPassword(accountId, req.password());
+        return ResponseEntity.ok(
+                BaseResponse.success(ResponseMessage.PASSWORD_VERIFICATION_SUCCESS)
+        );
+    }
+
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountController.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountController.java
@@ -1,5 +1,7 @@
 package com.lp.v2.domains.account;
 
+import com.lp.v2.common.response.BaseResponse;
+import com.lp.v2.common.response.ResponseMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,8 +17,10 @@ public class AccountController {
     private final AccountService accountService;
 
     @PostMapping
-    public ResponseEntity<String> createAccount(@RequestBody AccountCreateReq req) {
+    public ResponseEntity<BaseResponse> createAccount(@RequestBody AccountCreateReq req) {
         accountService.create(req);
-        return ResponseEntity.ok("계정 생성이 완료되었습니다.");
+        return ResponseEntity.ok(
+                BaseResponse.success(ResponseMessage.ACCOUNT_CREATED_SUCCESS)
+        );
     }
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountEntity.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountEntity.java
@@ -6,11 +6,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
 public class AccountEntity extends Auditable {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE)
@@ -26,6 +28,10 @@ public class AccountEntity extends Auditable {
     @Column(nullable = true)
     private String password;
 
+    @Column(name = "is_deleted", nullable = false)
+    private Boolean isDeleted = false;
+
+
     @Builder
     public AccountEntity(String username, String email, String password) {
         this.username = username;
@@ -40,4 +46,9 @@ public class AccountEntity extends Auditable {
     public void updatePassword(String password) {
         this.password = password;
     }
+
+    public void delete() {
+        this.isDeleted = true;
+    }
+
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountEntity.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountEntity.java
@@ -32,4 +32,12 @@ public class AccountEntity extends Auditable {
         this.email = email;
         this.password = password;
     }
+
+    public void updateUsername(String username) {
+        this.username = username;
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountInfoRes.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountInfoRes.java
@@ -1,0 +1,18 @@
+package com.lp.v2.domains.account;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AccountInfoRes {
+    private final String email;
+    private final String username;
+
+    public static AccountInfoRes fromEntity(AccountEntity entity) {
+        return AccountInfoRes.builder()
+            .email(entity.getEmail())
+            .username(entity.getUsername())
+            .build();
+    }
+}

--- a/src/main/java/com/lp/v2/domains/account/AccountService.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountService.java
@@ -26,6 +26,7 @@ public class AccountService {
         );
     }
 
+    @Transactional(readOnly = true)
     public Long getByEmailAndPassword(String email, String password) {
         AccountEntity account = accountRepository.findByEmail(email)
                 .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));
@@ -37,6 +38,7 @@ public class AccountService {
         return account.getId();
     }
 
+    @Transactional(readOnly = true)
     public AccountInfoRes getInfo(Long accountId) {
         AccountEntity account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));
@@ -44,6 +46,7 @@ public class AccountService {
         return AccountInfoRes.fromEntity(account);
     }
 
+    @Transactional(readOnly = true)
     public void verifyPassword(Long accountId, String password) {
         AccountEntity account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));

--- a/src/main/java/com/lp/v2/domains/account/AccountService.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountService.java
@@ -43,4 +43,13 @@ public class AccountService {
 
         return AccountInfoRes.fromEntity(account);
     }
+
+    public void verifyPassword(Long accountId, String password) {
+        AccountEntity account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));
+
+        if (!passwordService.verifyPassword(password, account.getPassword())) {
+            throw new IllegalArgumentException("패스워드가 일치하지 않습니다.");
+        }
+    }
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountService.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountService.java
@@ -36,4 +36,11 @@ public class AccountService {
 
         return account.getId();
     }
+
+    public AccountInfoRes getInfo(Long accountId) {
+        AccountEntity account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));
+
+        return AccountInfoRes.fromEntity(account);
+    }
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountService.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountService.java
@@ -73,4 +73,12 @@ public class AccountService {
 
         accountRepository.save(account);
     }
+
+    public void delete(Long accountId) {
+        AccountEntity account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));
+
+        account.delete();
+        accountRepository.save(account);
+    }
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountService.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountService.java
@@ -52,4 +52,22 @@ public class AccountService {
             throw new IllegalArgumentException("패스워드가 일치하지 않습니다.");
         }
     }
+
+    public void update(Long accountId, AccountUpdateReq req) {
+        AccountEntity account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("계정을 찾을 수 없습니다."));
+
+        if (req.username() != null) {
+            account.updateUsername(req.username());
+        }
+
+        if (req.existingPassword() != null && req.newPassword() != null) {
+            if (!passwordService.verifyPassword(req.existingPassword(), account.getPassword())) {
+                throw new IllegalArgumentException("기존 패스워드가 일치하지 않습니다.");
+            }
+            account.updatePassword(passwordService.encodePassword(req.newPassword()));
+        }
+
+        accountRepository.save(account);
+    }
 }

--- a/src/main/java/com/lp/v2/domains/account/AccountUpdateReq.java
+++ b/src/main/java/com/lp/v2/domains/account/AccountUpdateReq.java
@@ -1,0 +1,8 @@
+package com.lp.v2.domains.account;
+
+public record AccountUpdateReq(
+        String username,
+        String existingPassword,
+        String newPassword
+) {
+}

--- a/src/main/java/com/lp/v2/domains/account/PasswordVerifyReq.java
+++ b/src/main/java/com/lp/v2/domains/account/PasswordVerifyReq.java
@@ -1,0 +1,6 @@
+package com.lp.v2.domains.account;
+
+public record PasswordVerifyReq(
+    String password
+) {
+}

--- a/src/main/java/com/lp/v2/domains/auth/AuthController.java
+++ b/src/main/java/com/lp/v2/domains/auth/AuthController.java
@@ -23,7 +23,8 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<AuthLogInRes> logIn (@RequestBody AuthLogInReq req) {
         TokenPair tokenPair = authService.logIn(req);
-        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenPair.getRefreshToken())
+
+        ResponseCookie cookie = ResponseCookie.from("refreshToken", tokenPair.refreshToken())
                 .httpOnly(true)
                 .secure(true)
                 .path("/")
@@ -33,7 +34,7 @@ public class AuthController {
 
         return ResponseEntity.ok()
                 .header(HttpHeaders.SET_COOKIE, cookie.toString())
-                .body(AuthLogInRes.of(tokenPair.getAccessToken()));
+                .body(AuthLogInRes.of(tokenPair.accessToken()));
     }
 
 }

--- a/src/main/java/com/lp/v2/domains/auth/dto/TokenPair.java
+++ b/src/main/java/com/lp/v2/domains/auth/dto/TokenPair.java
@@ -1,11 +1,5 @@
 package com.lp.v2.domains.auth.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
-@Getter
-@AllArgsConstructor
-public class TokenPair {
-    private final String accessToken;
-    private final String refreshToken;
+public record TokenPair(String accessToken, String refreshToken) {
 }

--- a/src/main/java/com/lp/v2/domains/auth/service/AuthService.java
+++ b/src/main/java/com/lp/v2/domains/auth/service/AuthService.java
@@ -1,7 +1,6 @@
 package com.lp.v2.domains.auth.service;
 
 import com.lp.v2.domains.account.AccountService;
-import com.lp.v2.domains.auth.core.RefreshTokenEntity;
 import com.lp.v2.domains.auth.dto.AuthLogInReq;
 import com.lp.v2.domains.auth.dto.TokenPair;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +19,7 @@ public class AuthService {
     public TokenPair logIn(AuthLogInReq req) {
         Long accountId = accountService.getByEmailAndPassword(req.email(), req.password());
         TokenPair tokenPair = jwtService.create(accountId);
-        refreshTokenService.create(tokenPair.getRefreshToken(), accountId);
+        refreshTokenService.create(tokenPair.refreshToken(), accountId);
         return tokenPair;
     }
 

--- a/src/main/java/com/lp/v2/domains/auth/service/JwtService.java
+++ b/src/main/java/com/lp/v2/domains/auth/service/JwtService.java
@@ -9,10 +9,11 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 class JwtService {
     private final JwtProvider jwtProvider;
+    private static final String BEARER_PREFIX = "Bearer ";
 
     TokenPair create(Long accountId) {
         return new TokenPair (
-                jwtProvider.createAccessToken(accountId.toString()),
+                BEARER_PREFIX + jwtProvider.createAccessToken(accountId.toString()),
                 jwtProvider.createRefreshToken(accountId.toString())
         );
     }

--- a/src/main/java/com/lp/v2/exception/ExpiredTokenException.java
+++ b/src/main/java/com/lp/v2/exception/ExpiredTokenException.java
@@ -1,0 +1,15 @@
+package com.lp.v2.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+// 3) 토큰이 만료된 경우
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class ExpiredTokenException extends RuntimeException {
+    public ExpiredTokenException() {
+        super("토큰이 만료되었습니다.");
+    }
+    public ExpiredTokenException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/lp/v2/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/lp/v2/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.lp.v2.exception;
 
+import com.lp.v2.common.response.BaseResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -12,17 +13,28 @@ import java.util.Map;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<?> handleIllegalArgument(
+    public ResponseEntity<BaseResponse> handleIllegalArgument(
             IllegalArgumentException ex, WebRequest request) {
-
-        Map<String, Object> body = Map.of(
-                "timestamp", Instant.now().toString(),
-                "status", HttpStatus.CONFLICT.value(),
-                "error", "Conflict",
-                "message", ex.getMessage(),
-                "path", request.getDescription(false).replace("uri=", "")
-        );
-
-        return new ResponseEntity<>(body, HttpStatus.CONFLICT);
+        BaseResponse response = BaseResponse.builder()
+                .success(false)
+                .message(ex.getMessage())
+                .timestamp(Instant.now().toString())
+                .status(HttpStatus.CONFLICT.value())
+                .build();
+        return ResponseEntity
+                .status(HttpStatus.CONFLICT)
+                .body(response);
     }
+
+    @ExceptionHandler({
+            UnauthenticatedException.class,
+            InvalidTokenException.class,
+            ExpiredTokenException.class
+    })
+    public ResponseEntity<BaseResponse> handleAuthExceptions(RuntimeException ex) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(BaseResponse.fail(ex.getMessage()));
+    }
+
 }

--- a/src/main/java/com/lp/v2/exception/InvalidTokenException.java
+++ b/src/main/java/com/lp/v2/exception/InvalidTokenException.java
@@ -1,0 +1,14 @@
+package com.lp.v2.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException() {
+        super("유효하지 않은 토큰입니다.");
+    }
+    public InvalidTokenException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/lp/v2/exception/UnauthenticatedException.java
+++ b/src/main/java/com/lp/v2/exception/UnauthenticatedException.java
@@ -1,0 +1,16 @@
+package com.lp.v2.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+// 1) 인증 정보가 없는 경우
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UnauthenticatedException extends RuntimeException {
+    public UnauthenticatedException() {
+        super("인증 정보가 없습니다.");
+    }
+    public UnauthenticatedException(String msg) {
+        super(msg);
+    }
+}
+

--- a/src/main/java/com/lp/v2/security/SecurityConfig.java
+++ b/src/main/java/com/lp/v2/security/SecurityConfig.java
@@ -62,7 +62,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/accounts").permitAll()
+                        .requestMatchers("/api/accounts/signup").permitAll()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .anyRequest().authenticated()

--- a/src/main/java/com/lp/v2/security/annotation/CurrentAccountId.java
+++ b/src/main/java/com/lp/v2/security/annotation/CurrentAccountId.java
@@ -1,0 +1,9 @@
+package com.lp.v2.security.annotation;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface CurrentAccountId {
+}

--- a/src/main/java/com/lp/v2/security/resolver/CurrentAccountIdArgumentResolver.java
+++ b/src/main/java/com/lp/v2/security/resolver/CurrentAccountIdArgumentResolver.java
@@ -1,0 +1,44 @@
+package com.lp.v2.security.resolver;
+
+import com.lp.v2.exception.InvalidTokenException;
+import com.lp.v2.exception.UnauthenticatedException;
+import com.lp.v2.security.annotation.CurrentAccountId;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class CurrentAccountIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CurrentAccountId.class)
+                && Long.class.isAssignableFrom(parameter.getParameterType());
+    }
+
+    @Override
+    public Long resolveArgument(MethodParameter parameter,
+                                  ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest,
+                                  WebDataBinderFactory binderFactory) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null) {
+            throw new UnauthenticatedException();
+        }
+        if (!auth.isAuthenticated() || "anonymousUser".equals(auth.getName())) {
+            throw new UnauthenticatedException();
+        }
+
+        // name 에 subject(accountId)를 넣었다 가정
+        String subject = auth.getName();
+        try {
+            return Long.valueOf(subject);
+        } catch (NumberFormatException ex) {
+            throw new InvalidTokenException("토큰 subject 형식 오류");
+        }
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
- [ ] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, local variables)
- [ ] Build
- [ ] Other...

## #️⃣ 연관된 이슈
#5 #11 

## 📝 작업 내용
- 계정 CRUD API를 작성했습니다.
- 기본 Response 형식을 정의했습니다.
- `@CurrentAccountId` 어노테이션을 추가해 컨트롤러에서 AccountId를 Parameter로 받을 수 있도록 했습니다.

### 💬 리뷰 요구사항 (선택)
- 에러 메시지 / 성공 메세지 통합하는 부분에서 좀 더 구체화하기 위해 필요한 부분
- 계정 생성 시 기존 탈퇴한 이메일을 제외하고서 계정 생성 가능 여부를 확인하는데, 만약 탈퇴하고 같은 이메일로 재가입한다면 이 경우는 어떻게 할까요?